### PR TITLE
Fix to calculation of 'deleting' files - prior code was matching any fil...

### DIFF
--- a/rsync-zenity.sh
+++ b/rsync-zenity.sh
@@ -75,7 +75,7 @@ fi
 
 zenity --text-info --title="Sync review ($num_files changes)" --filename=$log_file --width=500 --height=500 || exit 4
 
-num_deleted=`fgrep delet $log_file | wc -l`
+num_deleted=$(grep '^\*deleting ' $log_file | wc -l)
 if [ $num_deleted -ge 100 ]; then
   zenity --question --title="Sync" --text="$num_deleted files are going to be deleted from $dest, do you still want to continue?" --ok-label="Continue" || exit 4
 fi


### PR DESCRIPTION
Fix to calculation of 'deleting' files - prior code was matching any file with the substring 'delet' in it.
New code parse rsync 3 which starts log lines with '*deleting ' like
*deleting   xmlsh/xmlsh_ext/nexstra/module.xml
